### PR TITLE
Fixed a bug in EntityMoveEvent:

### DIFF
--- a/src/main/java/banana/pekan/firefly/event/events/EntityMoveEvent.java
+++ b/src/main/java/banana/pekan/firefly/event/events/EntityMoveEvent.java
@@ -17,7 +17,7 @@ public class EntityMoveEvent extends Event {
     public EntityMoveEvent(Entity entity, Vec3d movement) {
         this.entity = entity;
         this.movement = movement;
-        this.entityType = entity.getType();
+        this.entityType = entity == null ? null : entity.getType();
     }
 
     public static class Pre extends EntityMoveEvent {


### PR DESCRIPTION
- When an entity became 'null' the game crashed because the event tried to call entity.getType(), this has been fixed.